### PR TITLE
Unset line-length limit for `.nix` files

### DIFF
--- a/jasons_pre_commit_hooks/editor_config.ini
+++ b/jasons_pre_commit_hooks/editor_config.ini
@@ -236,8 +236,6 @@ max_line_length = 72
 # [1]: <https://github.com/NixOS/rfcs/blob/62d1245ec1eae275edb996229585637035c02538/rfcs/0166-nix-formatting.md#indentation>
 # editorconfig-checker-enable
 indent_size = 2
-
-[flake.lock]
 # Many of my flake.lock files contain a really long URL:
 #
 # editorconfig-checker-disable
@@ -257,10 +255,16 @@ indent_size = 2
 # hook to stop giving errors for that really long URL, so I’m removing
 # the line length limit for flake.lock files.
 #
+# I’m also unsetting the line length for .nix files as well. Most of the
+# time, my .nix files end up getting formatted using “nix fmt” [5]. The
+# formatter that “nix fmt” ends up using should be the thing that
+# enforces the line length limitation, not editorconfig-checker.
+#
 # editorconfig-checker-disable
 # [1]: <https://nix.dev/manual/nix/2.28/command-ref/new-cli/nix3-flake#lock-files>
 # [2]: <https://stackoverflow.com/a/52557585/7593853>
 # [3]: <https://github.com/editorconfig-checker/editorconfig-checker?tab=readme-ov-file#excluding-blocks>
 # [4]: <https://stackoverflow.com/a/244858/7593853>
+# [5]: <https://nix.dev/manual/nix/2.28/command-ref/new-cli/nix3-fmt>
 # editorconfig-checker-enable
 max_line_length = unset


### PR DESCRIPTION
See the commit message for detail. Closes #21.
