### PR TITLE
Disable line-length limitation for `.license` files

### DIFF
--- a/jasons_pre_commit_hooks/editor_config.ini
+++ b/jasons_pre_commit_hooks/editor_config.ini
@@ -227,7 +227,7 @@ insert_final_newline = true
 # editorconfig-checker-enable
 max_line_length = 72
 
-[{**.nix,flake.lock}]
+[{**.nix,flake.lock,**.license}]
 # I’m only using 2 for Nix files because the Nix ecosystem project
 # itself uses 2 spaces for indentation [1]. Also, when Nix generates a
 # flake.lock file, it uses 2 spaces for indentation.
@@ -260,11 +260,21 @@ indent_size = 2
 # formatter that “nix fmt” ends up using should be the thing that
 # enforces the line length limitation, not editorconfig-checker.
 #
+# Also, when writing .license files, you can’t really split values over
+# multiple lines because .license files contain SPDX-License-Identifier
+# tags and SPDX file tags [6]. There’s no way to split long
+# SPDX-License-Identifier tags or SPDX file tags over multiple lines
+# [7][8] so it doesn’t make sense to enforce a line length limit for
+# .license files.
+#
 # editorconfig-checker-disable
 # [1]: <https://nix.dev/manual/nix/2.28/command-ref/new-cli/nix3-flake#lock-files>
 # [2]: <https://stackoverflow.com/a/52557585/7593853>
 # [3]: <https://github.com/editorconfig-checker/editorconfig-checker?tab=readme-ov-file#excluding-blocks>
 # [4]: <https://stackoverflow.com/a/244858/7593853>
 # [5]: <https://nix.dev/manual/nix/2.28/command-ref/new-cli/nix3-fmt>
+# [6]: <https://reuse.software/spec-3.2#comment-headers>
+# [7]: <https://spdx.github.io/spdx-spec/v2.3/using-SPDX-short-identifiers-in-source-files>
+# [8]: <https://spdx.github.io/spdx-spec/v2.3/file-tags>
 # editorconfig-checker-enable
 max_line_length = unset


### PR DESCRIPTION
Closes #25.
