### PR TITLE
Make RSC use new id for Ruff pre-commit hook

### DIFF
--- a/jasons_pre_commit_hooks/repo_style_checker.py
+++ b/jasons_pre_commit_hooks/repo_style_checker.py
@@ -184,7 +184,7 @@ PCR_MYPY: Final = PreCommitRepoInfo(
 )
 PCR_RUFF: Final = PreCommitRepoInfo(
     url='https://github.com/astral-sh/ruff-pre-commit',
-    hook_ids=('ruff',)
+    hook_ids=('ruff-check',)
 )
 PCR_PRE_COMMIT_ITSELF: Final = PreCommitRepoInfo(
     url='https://github.com/pre-commit/pre-commit',


### PR DESCRIPTION
See the commit message for details. Closes #48.
