### PR TITLE
Make RSC no longer require flake-lock-updater

### DIFF
--- a/jasons_pre_commit_hooks/repo_style_checker.py
+++ b/jasons_pre_commit_hooks/repo_style_checker.py
@@ -158,10 +158,6 @@ PCR_FORBID_PATHS_THAT_MATCH: Final = PreCommitRepoInfo(
     hook_ids=('forbid-paths-that-match',),
     args=('--pattern', '^LICENSE', '--pattern', '^COPYING')
 )
-PCR_FLAKE_LOCK_UPDATER: Final = PreCommitRepoInfo(
-    url='https://github.com/Jayman2000/jasons-pre-commit-hooks',
-    hook_ids=('flake-lock-updater',)
-)
 PCR_LANGUAGE_FORMATTERS: Final = PreCommitRepoInfo(
     # editorconfig-checker-disable
     url='https://github.com/macisamuele/language-formatters-pre-commit-hooks',
@@ -237,7 +233,6 @@ PRE_COMMIT_REPOS_BY_PATH: Final = (
     (('VERSIONING.md',), PCR_UNRELEASED_COMMIT_CHECKER),
     (('**.nix',), PCR_NIX_PRE_COMMIT_HOOKS_FLAKE_CHECK),
     (('**.nix',), PCR_NIX_PRE_COMMIT_HOOKS_FMT),
-    (('**flake.lock',), PCR_FLAKE_LOCK_UPDATER),
     (('**.gd',), PCR_GDLINT),
 )
 


### PR DESCRIPTION
See the commit message for details. This pull request is related to #47, but it doesn’t completely deal with that issue.
